### PR TITLE
Ingress update: remove validator path, update validatorapi path

### DIFF
--- a/infra/aws-impl/manifests/ingress.yaml
+++ b/infra/aws-impl/manifests/ingress.yaml
@@ -10,8 +10,8 @@ metadata:
     allowSnippetAnnotations: true
     # validatorapi wants base path for some reason?
     nginx.ingress.kubernetes.io/configuration-snippet: |- 
-      if ($request_uri ~* "^/validatorapi/(.*)") {
-        rewrite ^/validatorapi/(.*)$ /$1 break;
+      if ($request_uri ~* "^/hl7validatorapi/(.*)") {
+        rewrite ^/hl7validatorapi/(.*)$ /$1 break;
       }
 spec:
   ingressClassName: nginx
@@ -23,20 +23,13 @@ spec:
     - host: inferno.hl7.org.au
       http:
         paths:
-        - path: /validatorapi
+        - path: /hl7validatorapi
           pathType: Prefix
           backend:
             service:
               name: validator-api
               port:
                 number: 4567
-        - path: /validator
-          pathType: Prefix
-          backend:
-            service:
-              name: validator-web
-              port:
-                number: 80
         - path: /
           pathType: Prefix
           backend:

--- a/infra/aws-impl/manifests/ingress.yaml
+++ b/infra/aws-impl/manifests/ingress.yaml
@@ -29,7 +29,7 @@ spec:
             service:
               name: validator-api
               port:
-                number: 4567
+                number: 3500
         - path: /
           pathType: Prefix
           backend:


### PR DESCRIPTION
Latest changes from Pavel+Ilya  have changed the paths that inferno services use so the ingress needs to be updated accordingly.

The nginx config snippet that strips the base path is still present in this config as the previous validator api expected the base path to be stripped.

`    nginx.ingress.kubernetes.io/configuration-snippet: |- 
      if ($request_uri ~* "^/hl7validatorapi/(.*)") {
        rewrite ^/hl7validatorapi/(.*)$ /$1 break;
      }
`

Need confirmation form @ir4y or @projkov if this config snippet that strips base path is required before merging.

