### PR TITLE
Change redis mount type to avoid permission issues

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   inferno:
     build:
@@ -57,7 +56,7 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
     volumes:
-      - ./data/redis:/data
+      - redis-data:/data
     command: redis-server --appendonly yes
   postgres:
     image: postgres:16.2-alpine3.19
@@ -70,3 +69,5 @@ services:
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: inferno
+volumes:
+  redis-data:


### PR DESCRIPTION
Use a named volume instead of a bind mount for the redis volume to avoid host permission issues.

Remove the deprecated version field from the top of the docker compose yaml to suppress the warning.

Resolves #256