### PR TITLE
chore: changelog 1.4.1/1.4.2 + tag-version guard (prep v1.4.2 release)

### DIFF
--- a/.github/workflows/publish-gem.yaml
+++ b/.github/workflows/publish-gem.yaml
@@ -16,6 +16,17 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.6
+      # Guard against version drift: a release tag must match lib/.../version.rb so we
+      # never publish (or tag) a version that doesn't match the code.
+      - name: Verify tag matches gem version
+        if: github.event_name == 'release'
+        run: |
+          GEM_VERSION="v$(ruby -r ./lib/au_core_test_kit/version -e 'print AUCoreTestKit::VERSION')"
+          echo "Release tag: ${{ github.ref_name }} | gem version: ${GEM_VERSION}"
+          if [ "${GEM_VERSION}" != "${{ github.ref_name }}" ]; then
+            echo "::error::Release tag ${{ github.ref_name }} does not match gem version ${GEM_VERSION} (lib/au_core_test_kit/version.rb)"
+            exit 1
+          fi
       - name: Install dependencies
         run: bundle install
       - name: Configure RubyGems credentials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.4.2
+* Correct the validation suite `baseEngine` and IG path configuration.
+
+# 1.4.1
+* Regenerate the AU Core 2.0.0 suite using the new external `inferno_suite_generator`.
+* Pin the tx.dev terminology server ecosystem to work around a tx-registry bug in the validator.
+* Refine test generation: must-support slice handling, search-parameter comparators and defaults, and skip-generation for Medication and DiagnosticReport resources.
+
 # 1.4.0
 * Add a suite for AU Core 2.0.0.
 * Fix IG link in test suite generator.


### PR DESCRIPTION
Part of hl7au/au-fhir-inferno#287.

The gem is at `1.4.2` in `version.rb` but only `1.4.0` was ever tagged/released/published, so downstream `au_core_test_kit ~> 1.4.0` resolves ~30 commits behind current code (which is why au-fhir-inferno pins by git SHA).

This PR prepares the missing release:
- **CHANGELOG**: add `1.4.1` and `1.4.2` entries.
- **publish-gem.yaml**: add a guard that fails the publish if the release tag != `v`+`AUCoreTestKit::VERSION` — prevents this tag/version drift recurring.

### Next (after merge) — cutting the release
Creating a GitHub Release `v1.4.2` on `master` fires `publish-gem.yaml` → `gem push` to RubyGems (uses the existing `RUBYGEMSKEY`). That publish is **irreversible**, so it's a deliberate separate step. Once `1.4.2` is on RubyGems, au-fhir-inferno's prod `Gemfile` (`~> 1.4.0`, already allows 1.4.2) just needs a lockfile refresh — no SHA pin needed.

Validated: workflow YAML parses; the tag/version check resolves `v1.4.2` locally.