### PR TITLE
fix: declare suite `id` before `fhir_resource_validator` (fixes AU Core v1/v2 validator-session collision)

### DIFF
--- a/lib/au_core_test_kit/generated/v1.0.0/au_core_test_suite.rb
+++ b/lib/au_core_test_kit/generated/v1.0.0/au_core_test_suite.rb
@@ -45,6 +45,14 @@ module AUCoreTestKit
       )
       version VERSION
 
+      # `id` MUST be declared before `fhir_resource_validator`: the validator captures the
+      # suite id eagerly as its `test_suite_id` (Inferno keys validator sessions on it). If
+      # `id` comes after, the capture falls back to the base-class name
+      # "Inferno::Entities::TestSuite", which every affected suite then shares as one
+      # validator session — collapsing AU Core 1.0.0 and 2.0.0 onto a single validator
+      # engine and causing intermittent "Unable to resolve profile ...|<version>" errors.
+      id :au_core_v100
+
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
 
       def self.metadata
@@ -87,8 +95,6 @@ module AUCoreTestKit
           url: 'https://build.fhir.org/ig/hl7au/au-fhir-core/'
         }
       ]
-
-      id :au_core_v100
 
       input :url,
             title: 'FHIR Endpoint',

--- a/lib/au_core_test_kit/generated/v2.0.0/au_core_test_suite.rb
+++ b/lib/au_core_test_kit/generated/v2.0.0/au_core_test_suite.rb
@@ -46,6 +46,14 @@ module AUCoreTestKit
       )
       version VERSION
 
+      # `id` MUST be declared before `fhir_resource_validator`: the validator captures the
+      # suite id eagerly as its `test_suite_id` (Inferno keys validator sessions on it). If
+      # `id` comes after, the capture falls back to the base-class name
+      # "Inferno::Entities::TestSuite", which every affected suite then shares as one
+      # validator session — collapsing AU Core 1.0.0 and 2.0.0 onto a single validator
+      # engine and causing intermittent "Unable to resolve profile ...|<version>" errors.
+      id :au_core_v200
+
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
 
       def self.metadata
@@ -92,8 +100,6 @@ module AUCoreTestKit
           url: 'https://build.fhir.org/ig/hl7au/au-fhir-core/index.html'
         }
       ]
-
-      id :au_core_v200
 
       input :url,
             title: 'FHIR Endpoint',


### PR DESCRIPTION
## Summary
The generated `au_core_v100` and `au_core_v200` suites declare `fhir_resource_validator` **before** their `id :au_core_vXXX`. Because of how inferno_core captures the validator's `test_suite_id`, this makes **both** suites' `:default` validators key on the literal base-class name `Inferno::Entities::TestSuite` — so both AU Core IG versions share **one** validator-wrapper session/engine, and validations intermittently fail with:

```
java.lang.Error: Unable to resolve profile http://hl7.org.au/fhir/core/StructureDefinition/au-core-*|<version>
    at org.hl7.fhir.validation.ValidationEngine.asSdList(...)
```

This PR moves `id :au_core_vXXX` **above** the `fhir_resource_validator` block in both generated suites.

## Root cause (two links, both verified live)

**Link 1 — inferno_core captures `id` eagerly, and `@base_id` leaks from the base class.**
`fhir_resource_validator` builds `Validator.new(name, id, …)` at declaration time (`lib/inferno/dsl/fhir_resource_validation.rb`), freezing the runnable's current `id` as the validator's `test_suite_id`. `Runnable#id` falls back to `@base_id`, and inferno_core copies `@base_id` from the base class onto every subclass — `VARIABLES_NOT_TO_COPY` (`lib/inferno/dsl/runnable.rb`) lists only `:@id`/`:@database_id`, **not** `:@base_id`. So before a subclass sets its own `id`, `id` returns the base-class name `"Inferno::Entities::TestSuite"`.

**Link 2 — declaration order in these suites (the trigger this PR fixes).**
In `generated/v1.0.0/au_core_test_suite.rb` and `generated/v2.0.0/au_core_test_suite.rb`, `fhir_resource_validator` is evaluated *before* `id :au_core_vXXX`, so the validator captures `"Inferno::Entities::TestSuite"` instead of the real suite id. `custom_suites/validation_suite.rb` declares `id :validations` **first**, so it was never affected — confirming the ordering is the trigger.

**Effect.** Inferno keys validator sessions on `(test_suite_id, validator_name, suite_options)`. With both au_core validators keyed `("Inferno::Entities::TestSuite","default","[]")`, the two IG versions collapse onto one wrapper session. The validator-wrapper reuses the cached engine by session id and ignores the request `igs`, so whichever version built the engine wins and the other version's profile can't be resolved.

## Evidence (production + dev, sparkey)
- Live in the pod: both suites' `:default` validators reported `test_suite_id == "Inferno::Entities::TestSuite"`; a minimal repro (`Class.new(Inferno::TestSuite){ fhir_resource_validator{…}; id :x }`) reproduced it, and declaring `id` first produced the correct id.
- Inferno DB `validator_sessions`: an actively-updated row keyed `Inferno::Entities::TestSuite` served **both** `hl7.fhir.au.core#1.0.0` and `#2.0.0` requests, while the correct `au_core_v100` / `au_core_v200` rows sat stale/unused.
- Validator log: `Cached session exists … Cache size = 8` immediately followed by `Unable to resolve profile …au-core-patient|1.0.0` (and, after other changes, the `|2.0.0` variant) — i.e. the failure flipped between versions by run order, the signature of a shared session, not a version-specific defect.

## Verification of this fix
With `id` declared first, both validators capture their real ids:

| suite | before | after |
|---|---|---|
| `au_core_v100` | `Inferno::Entities::TestSuite` | `au_core_v100` |
| `au_core_v200` | `Inferno::Entities::TestSuite` | `au_core_v200` |
| `validations` | `validations` (already correct) | `validations` |

Confirmed end-to-end on prod (via the interim workaround below): running `au_core_v200` and `au_core_v100` concurrently produced **distinct** per-suite validator sessions and **0** `Unable to resolve profile` errors, where previously they collided.

## Related — deployment findings + interim patch
Investigated and mitigated in the deployment repo `hl7au/au-fhir-inferno`:
- **Interim workaround (this bug):** https://github.com/hl7au/au-fhir-inferno/pull/124 — a boot-time `finalize!` hook that re-keys any validator still carrying `Inferno::Entities::TestSuite` to its real suite id. **This PR is the durable upstream fix; once released and picked up, that workaround can be removed.**
- Adjacent validator-wrapper hardening surfaced during the investigation: [#121](https://github.com/hl7au/au-fhir-inferno/pull/121) (wrapper 1.0.68→1.0.78 / core 6.9.7 — a separate `CanonicalResourceManager.copy()` clone desync), [#123](https://github.com/hl7au/au-fhir-inferno/pull/123) (drop base-engine presets). Full write-up in that repo's `VALIDATOR_OPTIMIZATION.md`.

## Follow-up
The generated files are fixed here for the released gem, but the emitting template in **InfernoSuiteGenerator** (`hl7au/inferno_suite_generator`) should also place `id` before `fhir_resource_validator`, otherwise regeneration reverts this. Happy to raise that PR too.

/cc @projkov for review.