### PR TITLE
Validate reference targets through the supported validator DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+* Validate reference targets through `Validator#resource_is_valid?` instead of the
+  `Validator` internals inferno_core removed in v1.1.0, so the kit runs on
+  inferno_core 1.1.0 through 1.4.x as well as 1.0.x.
+
 # 1.4.5
 * Add a suite for AU Core 3.0.0-ballot1
 

--- a/lib/au_core_test_kit/reference_resolution_test.rb
+++ b/lib/au_core_test_kit/reference_resolution_test.rb
@@ -169,22 +169,17 @@ module AUCoreTestKit
     def resource_is_valid_with_target_profile?(resource, target_profile)
       return true if target_profile.blank?
 
-      # Only need to know if the resource is valid.
-      # Calling resource_is_valid? causes validation errors to be logged.
       validator = find_validator(:default)
 
       target_profile_with_version = target_profile == "http://hl7.org.au/fhir/StructureDefinition/au-specimen" ? target_profile : "#{target_profile}|#{metadata.profile_version}"
 
-      validator_response = validator.validate(resource, target_profile_with_version)
-      outcome = validator.operation_outcome_from_hl7_wrapped_response(validator_response)
-
-      message_hashes = outcome.issue&.map { |issue| validator.message_hash_from_issue(issue, resource) } || []
-
-      message_hashes.concat(validator.additional_validation_messages(resource, target_profile_with_version))
-
-      validator.filter_messages(message_hashes)
-
-      message_hashes.none? { |message_hash| message_hash[:type] == 'error' }
+      # Only the boolean matters here, so add_messages_to_runnable is false: logging a
+      # validation message for every reference target would flood the test's messages.
+      # This is the supported way to validate without logging. The previous
+      # implementation hand-rolled the same thing out of Validator internals
+      # (operation_outcome_from_hl7_wrapped_response, message_hash_from_issue,
+      # filter_messages), all of which inferno_core removed in v1.1.0.
+      validator.resource_is_valid?(resource, target_profile_with_version, self, add_messages_to_runnable: false)
     end
   end
 end


### PR DESCRIPTION
## What

`AUCoreTestKit::ReferenceResolutionTest#resource_is_valid_with_target_profile?` now calls

```ruby
validator.resource_is_valid?(resource, target_profile_with_version, self, add_messages_to_runnable: false)
```

in place of the five-step sequence it previously hand-rolled out of `Validator` internals.

## Why

inferno_core removed `operation_outcome_from_hl7_wrapped_response`, `message_hash_from_issue` and `filter_messages` in v1.1.0 (inferno-framework/inferno-core#753), which the release notes describe as tidying up "private methods that some test kits were known to be incorrectly relying upon". This kit is one of them. Unlike the equivalent block in `inferno_suite_generator`, this one is not wrapped in a rescue, so on inferno_core >= 1.1.0 the 18 AU Core v1.0.0 reference-resolution tests raise `NoMethodError` outright.

The v2.0.0, v2.1.0-draft and v3.0.0-ballot1 suites are unaffected by this file: they include `InfernoSuiteGenerator::ReferenceResolutionTest`, which was already fixed on the generator's `main`. This module is the last remaining call site, and with it fixed the kit runs on inferno_core 1.4.x.

Together with the `inferno_core ~> 1.0.6` cap in `au_ps_inferno` (hl7au/au-ps-inferno#113), this is what holds `inferno.hl7.org.au` on inferno_core 1.0.8 while upstream is at 1.4.2.

## Equivalence

`resource_is_valid?` with `add_messages_to_runnable: false` performs the same steps the removed block did, in the same order: build the message hashes from the validator response, append `additional_validation_messages`, apply `exclude_unresolved_url_message` and the suite's `exclude_message` filter, then return whether any `error` remains. Comparing inferno_core 1.0.8 with 1.4.2 across the entire gem, `lib/inferno/dsl/fhir_resource_validation.rb` is the only file that loses any method and no file is removed, so this call site is the whole of the runtime incompatibility.

The profile-canonical logic is deliberately untouched: `target_profile_with_version` still appends `metadata.profile_version` to everything except `au-specimen`. Changing that is a separate behavioural question.

## Compatibility

`resource_is_valid?` has taken `(resource, profile_url, runnable, add_messages_to_runnable:)` since 1.0.6, so this branch runs unchanged on the currently released inferno_core 1.0.8 as well as on 1.4.2. It can be released before any host application moves, and it lets a host A/B the inferno_core bump with the test kit held constant.

## Base

Rebased onto `master`, so it sits on top of 1.4.5 and the AU Core v3.0.0-ballot1 suite. Needs a version bump before release.

Refs hl7au/au-fhir-inferno#162