### PR TITLE
Add per-PR preview environments driven by the preview label

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -1,11 +1,11 @@
-# Preview images for `preview`-labelled PRs. Pushing the label builds this PR's
-# app and nginx images; the aucore-previews ApplicationSet in aehrc/sparked-argo
-# then provisions aucore-pr-<n>.preview.inferno.sparked-fhir.com from them, and
-# tears it down when the label is removed or the PR closes. New commits rebuild
-# and the environment follows the PR head automatically.
+# Preview image for `preview`-labelled PRs. Pushing the label builds this PR's
+# app image; the aucore-previews ApplicationSet in aehrc/sparked-argo then
+# provisions aucore-pr-<n>.preview.inferno.sparked-fhir.com from it, and tears
+# it down when the label is removed or the PR closes. New commits rebuild and
+# the environment follows the PR head automatically.
 #
-# The image tags MUST stay <head_sha>-pr and <head_sha>-nginx-pr: the
-# ApplicationSet templates exactly those tags from the PR's head commit.
+# The image tag MUST stay <head_sha>-pr: the ApplicationSet templates exactly
+# that tag from the PR's head commit.
 #
 # Note: this only works for branch PRs, not fork PRs. A fork PR's GITHUB_TOKEN is
 # read-only, so the ghcr push fails. The same limitation exists for the aggregator
@@ -21,7 +21,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 # A new commit supersedes any in-flight build for the same PR: the preview always
-# targets the head SHA, so a superseded build's images would never be pulled.
+# targets the head SHA, so a superseded build's image would never be pulled.
 concurrency:
   group: build-preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -52,11 +52,3 @@ jobs:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.pull_request.head.sha }}-pr
-
-      - name: Build and push nginx image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./nginx.Dockerfile
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.pull_request.head.sha }}-nginx-pr

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -1,0 +1,62 @@
+# Preview images for `preview`-labelled PRs. Pushing the label builds this PR's
+# app and nginx images; the aucore-previews ApplicationSet in aehrc/sparked-argo
+# then provisions aucore-pr-<n>.preview.inferno.sparked-fhir.com from them, and
+# tears it down when the label is removed or the PR closes. New commits rebuild
+# and the environment follows the PR head automatically.
+#
+# The image tags MUST stay <head_sha>-pr and <head_sha>-nginx-pr: the
+# ApplicationSet templates exactly those tags from the PR's head commit.
+#
+# Note: this only works for branch PRs, not fork PRs. A fork PR's GITHUB_TOKEN is
+# read-only, so the ghcr push fails. The same limitation exists for the aggregator
+# previews in au-fhir-inferno.
+name: Build Preview Images
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# A new commit supersedes any in-flight build for the same PR: the preview always
+# targets the head SHA, so a superseded build's images would never be pulled.
+concurrency:
+  group: build-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push-images:
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push app image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.pull_request.head.sha }}-pr
+
+      - name: Build and push nginx image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./nginx.Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.pull_request.head.sha }}-nginx-pr

--- a/.github/workflows/preview-comment.yaml
+++ b/.github/workflows/preview-comment.yaml
@@ -1,0 +1,88 @@
+# Posts (and keeps updated) a single sticky comment on a PR that carries the
+# `preview` label, pointing at its ephemeral preview environment. Polls the URL
+# and flips the comment to "live" once it serves, and notes teardown when the
+# label is removed or the PR closes. The env itself is created by the
+# aucore-previews ApplicationSet in aehrc/sparked-argo; this workflow is purely
+# the PR-side notice.
+name: Preview environment PR comment
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+# Don't stack poll jobs if the label is toggled repeatedly on one PR.
+concurrency:
+  group: preview-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    # Only react to the `preview` label (added/removed) or to a labelled PR closing.
+    if: >-
+      ((github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name == 'preview') ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Upsert preview comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const n = context.payload.pull_request.number;
+            const host = `aucore-pr-${n}.preview.inferno.sparked-fhir.com`;
+            const url = `https://${host}`;
+            const marker = '<!-- aucore-preview-env -->';
+            const action = context.payload.action;
+
+            async function upsert(body) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner, repo, issue_number: n, per_page: 100,
+              });
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: `${marker}\n${body}` });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: n, body: `${marker}\n${body}` });
+              }
+            }
+
+            // Label removed or PR closed: note teardown and stop.
+            if (action !== 'labeled') {
+              await upsert(`### 🧹 Preview environment torn down\n\n\`${host}\` has been removed.`);
+              return;
+            }
+
+            await upsert(
+              `### 🚀 Preview environment\n\nProvisioning at **${url}**: building this PR's images and syncing via ArgoCD. ` +
+              `Usually live within a few minutes; new commits update it automatically. ` +
+              `Remove the \`preview\` label or close the PR to tear it down.`
+            );
+
+            // Poll until it serves (image build + ArgoCD sync + validator startup).
+            const deadline = Date.now() + 12 * 60 * 1000;
+            let live = false;
+            while (Date.now() < deadline) {
+              await new Promise(r => setTimeout(r, 20000));
+              try {
+                const res = await fetch(url, { redirect: 'manual' });
+                if (res.status >= 200 && res.status < 400) { live = true; break; }
+              } catch (e) { /* DNS/connection not ready yet */ }
+            }
+
+            if (live) {
+              await upsert(
+                `### ✅ Preview environment live\n\n**${url}**\n\n` +
+                `Running this PR's image with the stock Inferno UI. New commits update it; ` +
+                `remove the \`preview\` label or close the PR to tear it down.`
+              );
+            } else {
+              await upsert(
+                `### ⏳ Preview environment still provisioning\n\n**${url}** is taking longer than usual ` +
+                `(image build + validator startup can take ~10 min). It should come up shortly.`
+              );
+            }

--- a/nginx.Dockerfile
+++ b/nginx.Dockerfile
@@ -1,0 +1,8 @@
+# Reverse proxy image for the per-PR preview environments
+# (aucore-pr-<n>.preview.inferno.sparked-fhir.com, see the aucore-previews
+# ApplicationSet in aehrc/sparked-argo). Bakes the same config/nginx.conf used by
+# local compose: it proxies / to http://inferno:4567 and /hl7validatorapi/ to
+# http://validator-api:3500/, which match the Service names the preview chart
+# creates. Pinned to a minor version for reproducible builds; bump deliberately.
+FROM nginx:1.31
+COPY ./config/nginx.conf /etc/nginx/nginx.conf

--- a/nginx.Dockerfile
+++ b/nginx.Dockerfile
@@ -1,8 +1,0 @@
-# Reverse proxy image for the per-PR preview environments
-# (aucore-pr-<n>.preview.inferno.sparked-fhir.com, see the aucore-previews
-# ApplicationSet in aehrc/sparked-argo). Bakes the same config/nginx.conf used by
-# local compose: it proxies / to http://inferno:4567 and /hl7validatorapi/ to
-# http://validator-api:3500/, which match the Service names the preview chart
-# creates. Pinned to a minor version for reproducible builds; bump deliberately.
-FROM nginx:1.31
-COPY ./config/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Applying the `preview` label to a PR here spins up an ephemeral environment at `aucore-pr-<n>.preview.inferno.sparked-fhir.com` running this PR's code with the stock Inferno suite UI, with no companion PR in au-fhir-inferno needed (hl7au/au-fhir-inferno#187). Removing the label or closing the PR tears it down; new commits update it automatically.

## What's in this PR

- **`.github/workflows/build-preview.yaml`**: on a `preview`-labelled PR, builds and pushes the app image to ghcr as `<head_sha>-pr`.
- **`.github/workflows/preview-comment.yaml`**: sticky PR comment that tracks the environment (provisioning, live, torn down).

## How it fits together

The environment is provisioned by the `aucore-previews` ApplicationSet in aehrc/sparked-argo (aehrc/sparked-argo#245 + #246), which watches this repo for `preview`-labelled PRs and renders the au-fhir-inferno Helm chart **from master** with this PR's image. The full stack (inferno + worker + validator + redis + in-namespace postgres) comes up per PR; only the image is PR-controlled.

There is no nginx in a preview (hl7au/au-fhir-inferno#191 gates it off): inferno-core serves its own UI, assets, and API at `/`, and the gateway routes `/hl7validatorapi` directly to the validator Service. `/` lands on the AU Core test kit page via inferno-core's own redirect.

**Merge order**: hl7au/au-fhir-inferno#191 and aehrc/sparked-argo#246 should land before the first PR gets labelled here.

Caveat: fork PRs can't push to ghcr with the default token, so previews work for branch PRs only (same limitation as the aggregator previews).
